### PR TITLE
ci: adiciona workflow de testes e2e com cypress

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,67 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Wait for Vercel Preview
+        uses: zentered/vercel-preview-url@v1.1.9
+        id: vercel_preview_url
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        with:
+          vercel_team_id: ${{ secrets.VERCEL_TEAM_ID }}
+          vercel_project_id: ${{ secrets.VERCEL_PROJECT_ID }}
+          max_timeout: 300
+
+      - name: Run Cypress tests
+        uses: cypress-io/github-action@v6
+        with:
+          config: baseUrl=${{ steps.vercel_preview_url.outputs.preview_url }}
+        env:
+          CYPRESS_BASE_URL: ${{ steps.vercel_preview_url.outputs.preview_url }}
+
+      - name: Run Cypress tests
+        uses: cypress-io/github-action@v6
+        with:
+          config: baseUrl=${{ steps.vercel_preview_url.outputs.preview_url }}
+          browser: chrome
+          headed: false
+        env:
+          CYPRESS_BASE_URL: ${{ steps.vercel_preview_url.outputs.preview_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Cypress screenshots
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots
+          retention-days: 7
+
+      - name: Upload Cypress videos
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: cypress-videos
+          path: cypress/videos
+          retention-days: 7

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -42,6 +42,7 @@ jobs:
         env:
           CYPRESS_BASE_URL: https://${{ steps.vercel_preview_url.outputs.preview_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CYPRESS_VERCEL_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Upload Cypress screenshots
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -36,18 +36,11 @@ jobs:
       - name: Run Cypress tests
         uses: cypress-io/github-action@v6
         with:
-          config: baseUrl=${{ steps.vercel_preview_url.outputs.preview_url }}
-        env:
-          CYPRESS_BASE_URL: ${{ steps.vercel_preview_url.outputs.preview_url }}
-
-      - name: Run Cypress tests
-        uses: cypress-io/github-action@v6
-        with:
-          config: baseUrl=${{ steps.vercel_preview_url.outputs.preview_url }}
+          config: baseUrl=https://${{ steps.vercel_preview_url.outputs.preview_url }}
           browser: chrome
           headed: false
         env:
-          CYPRESS_BASE_URL: ${{ steps.vercel_preview_url.outputs.preview_url }}
+          CYPRESS_BASE_URL: https://${{ steps.vercel_preview_url.outputs.preview_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Cypress screenshots

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           CYPRESS_BASE_URL: https://${{ steps.vercel_preview_url.outputs.preview_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CYPRESS_VERCEL_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          CYPRESS_VERCEL_PROTECTION_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Upload Cypress screenshots
         uses: actions/upload-artifact@v4

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,10 +2,18 @@ import { defineConfig } from "cypress";
 
 export default defineConfig({
   e2e: {
-    setupNodeEvents() {
-      // implement node event listeners here
+    setupNodeEvents(on, config) {
+      // Garante que a variável de ambiente seja passada corretamente
+      config.env.VERCEL_PROTECTION_BYPASS =
+        process.env.CYPRESS_VERCEL_PROTECTION_BYPASS;
+      return config;
     },
     baseUrl: process.env.CYPRESS_BASE_URL || "http://localhost:3000",
+    // Configurações para melhor compatibilidade com Vercel
+    chromeWebSecurity: false,
+    defaultCommandTimeout: 10000,
+    requestTimeout: 10000,
+    responseTimeout: 10000,
   },
   viewportWidth: 1280,
   viewportHeight: 720,

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,11 +2,13 @@ import { defineConfig } from "cypress";
 
 export default defineConfig({
   e2e: {
-    setupNodeEvents(on, config) {
+    setupNodeEvents() {
       // implement node event listeners here
     },
-    baseUrl: "http://localhost:3000",
+    baseUrl: process.env.CYPRESS_BASE_URL || "http://localhost:3000",
   },
   viewportWidth: 1280,
   viewportHeight: 720,
+  video: true,
+  screenshotOnRunFailure: true,
 });

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -23,11 +23,12 @@ Cypress.on("window:before:load", (win) => {
       const [url, config = {}] = args;
 
       // Adiciona o header de autenticação
-      const bypassSecret = Cypress.env("VERCEL_BYPASS");
+      // Corrigido: usando VERCEL_PROTECTION_BYPASS em vez de VERCEL_BYPASS
+      const bypassSecret = Cypress.env("VERCEL_PROTECTION_BYPASS");
       if (bypassSecret) {
         config.headers = {
           ...config.headers,
-          "x-vercel-automation-bypass-secret": bypassSecret,
+          "x-vercel-protection-bypass": bypassSecret,
         };
       }
 
@@ -38,12 +39,17 @@ Cypress.on("window:before:load", (win) => {
 
 // Adiciona o header também para requisições diretas do Cypress
 beforeEach(() => {
-  const bypassSecret = Cypress.env("VERCEL_BYPASS");
+  // Corrigido: usando VERCEL_PROTECTION_BYPASS
+  const bypassSecret = Cypress.env("VERCEL_PROTECTION_BYPASS");
 
   if (bypassSecret) {
     // Intercepta TODAS as requisições para adicionar o header
     cy.intercept("**/*", (req) => {
-      req.headers["x-vercel-automation-bypass-secret"] = bypassSecret;
+      // Corrigido: usando o header correto do Vercel
+      req.headers["x-vercel-protection-bypass"] = bypassSecret;
     });
   }
+
+  // Log para debug (pode remover depois de funcionar)
+  cy.log("Vercel Bypass Secret configurado:", !!bypassSecret);
 });

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -14,4 +14,14 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+import "./commands";
+
+beforeEach(() => {
+  const bypassSecret = Cypress.env("VERCEL_BYPASS");
+
+  if (bypassSecret) {
+    cy.intercept("**/*", (req) => {
+      req.headers["x-vercel-automation-bypass-secret"] = bypassSecret;
+    });
+  }
+});


### PR DESCRIPTION
Adiciona workflow do GitHub Actions para rodar testes E2E do Cypress nos deploys da Vercel

## O que foi feito
- ✅ Configurado GitHub Actions workflow
- ✅ Integração com preview URLs da Vercel
- ✅ Upload de screenshots/vídeos em caso de falha

## Checklist
- [ ] Secrets configurados no GitHub
- [ ] Testes rodando com sucesso